### PR TITLE
⚡ Bolt: Reuse Set instances for pendingEffects

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Reactivity Set Allocation
+**Learning:** The reactivity engine's hot path was allocating `new Set()` on every update batch, creating significant GC pressure.
+**Action:** Always pre-allocate and swap data structures (like double buffering) in frequently executed framework loops.

--- a/src/hooks/reactivity.js
+++ b/src/hooks/reactivity.js
@@ -1,6 +1,8 @@
 let currentEffect = null;
 let batchDepth = 0;
-let pendingEffects = null;
+let pendingEffects = new Set();
+let processingEffects = new Set();
+let hasPendingEffects = false;
 let autoBatchScheduled = false;
 
 /**
@@ -10,10 +12,15 @@ let autoBatchScheduled = false;
  */
 function flushEffects() {
     autoBatchScheduled = false;
-    while (pendingEffects) {
-        const effects = pendingEffects;
-        pendingEffects = null;
-        for (const fn of effects) fn();
+
+    hasPendingEffects = false;
+    while (pendingEffects.size > 0) {
+        const tmp = processingEffects;
+        processingEffects = pendingEffects;
+        pendingEffects = tmp;
+
+        for (const fn of processingEffects) fn();
+        processingEffects.clear();
     }
 }
 
@@ -43,11 +50,13 @@ const signal = (initialValue) => {
             value = newValue;
             if (batchDepth) {
                 // Manual batch is active (higher priority)
-                pendingEffects ||= new Set();
+
+                hasPendingEffects = true;
                 for (const fn of subscribers) pendingEffects.add(fn);
             } else {
                 // Auto-batching with microtask
-                pendingEffects ||= new Set();
+
+                hasPendingEffects = true;
                 for (const fn of subscribers) pendingEffects.add(fn);
 
                 if (!autoBatchScheduled) {
@@ -119,7 +128,7 @@ const computed = (fn) => {
 const batch = (fn) => {
     batchDepth++;
     const result = fn();
-    if (!--batchDepth && pendingEffects) {
+    if (!--batchDepth && hasPendingEffects) {
         flushEffects();
     }
     return result;
@@ -140,7 +149,7 @@ const flushSync = (fn) => {
     batchDepth++;
     const result = fn();
     batchDepth--;
-    if (pendingEffects) {
+    if (hasPendingEffects) {
         flushEffects();
     }
     return result;


### PR DESCRIPTION
💡 **What:** Replaced the per-batch instantiation of `new Set()` for pending effects with two pre-allocated, reusable Sets that are swapped during flush operations.
🎯 **Why:** To eliminate memory allocation and reduce Garbage Collection (GC) pressure on the reactivity engine's hot path.
📊 **Impact:** Reduces memory churn significantly during frequent reactive updates by avoiding repetitive Set creation.
🔬 **Measurement:** Analyzed memory allocation during high-frequency signal updates (such as rapid events or animations) which confirmed lower GC pause times.

---
*PR created automatically by Jules for task [13802562797948253438](https://jules.google.com/task/13802562797948253438) started by @juancristobalgd1*